### PR TITLE
Add input limit args to cropbox filter

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/launch/preprocessor.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/preprocessor.launch.xml
@@ -5,11 +5,18 @@
      "['/points_raw0', '/points_raw1', '/points_raw2', ...]"
      This syntax is also available from command line -->
     <arg name="input_points_raw_list" default="['/points_raw']" description="define as string_array"/>
-    <arg name="input_points_raw" default="/points_raw" description="define as string_array"/>
+    <arg name="input_points_raw" default="/points_raw" description="define as string"/>
     <arg name="output_points_raw" default="/points_raw/cropbox/filtered" description=""/>
     <arg name="tf_output_frame" default="base_link" description=""/>
     <arg name="separate_concatenate_node_and_time_sync_node" default="true" description=""/>
     <arg name="use_multiple_inputs" default="false" description="Set true if using multiple input topics." />
+    <arg name="min_x" default="-3.0" description="Crop Box Limit Min in X"/>
+    <arg name="max_x" default="3.0" description="Crop Box Limit Max in X"/>
+    <arg name="min_y" default="-2.0" description="Crop Box Limit Min in Y"/>
+    <arg name="max_y" default="3.0" description="Crop Box Limit Max in Y"/>
+    <arg name="min_z" default="0.0" description="Crop Box Limit Min in Z"/>
+    <arg name="max_z" default="2.5" description="Crop Box Limit Max in Z"/>
+    <arg name="negative" default="true" description="Crop zone: false->remove outside | true->remove inside"/>
    
     <node pkg="rclcpp_components" exec="component_container" name="pointcloud_preprocessor_container" >
     </node>
@@ -54,13 +61,13 @@
         <remap from="output" to="$(var output_points_raw)" />
         <param name="input_frame" value="$(var tf_output_frame)" />
         <param name="output_frame" value="$(var tf_output_frame)" />
-        <param name="min_x" value="-3.0" />
-        <param name="max_x" value="3.0" />
-        <param name="min_y" value="-2.0" />
-        <param name="max_y" value="3.0" />
-        <param name="min_z" value="0.0" />
-        <param name="max_z" value="2.5" />
-        <param name="negative" value="true" />
+        <param name="min_x" value="$(var min_x)" />
+        <param name="max_x" value="$(var max_x)" />
+        <param name="min_y" value="$(var min_y)" />
+        <param name="max_y" value="$(var max_y)" />
+        <param name="min_z" value="$(var min_z)" />
+        <param name="max_z" value="$(var max_z)" />
+        <param name="negative" value="$(var negative)" />
         </composable_node>
     </load_composable_node>  
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/preprocessor.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/preprocessor.launch.xml
@@ -9,13 +9,7 @@
     <arg name="output_points_raw" default="/points_raw/cropbox/filtered" description=""/>
     <arg name="tf_output_frame" default="base_link" description=""/>
     <arg name="separate_concatenate_node_and_time_sync_node" default="true" description=""/>
-    <arg name="min_x" default="-3.0" description="Crop Box Limit Min in X"/>
-    <arg name="max_x" default="3.0" description="Crop Box Limit Max in X"/>
-    <arg name="min_y" default="-2.0" description="Crop Box Limit Min in Y"/>
-    <arg name="max_y" default="3.0" description="Crop Box Limit Max in Y"/>
-    <arg name="min_z" default="0.0" description="Crop Box Limit Min in Z"/>
-    <arg name="max_z" default="2.5" description="Crop Box Limit Max in Z"/>
-    <arg name="negative" default="true" description="Crop zone: false->remove outside | true->remove inside"/>
+    <arg name="config_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/crop_box_filter_node.param.yaml" description="Path to config file"/>
    
     <node pkg="rclcpp_components" exec="component_container" name="pointcloud_preprocessor_container" >
     </node>
@@ -55,13 +49,7 @@
         <remap from="output" to="$(var output_points_raw)" />
         <param name="input_frame" value="$(var tf_output_frame)" />
         <param name="output_frame" value="$(var tf_output_frame)" />
-        <param name="min_x" value="$(var min_x)" />
-        <param name="max_x" value="$(var max_x)" />
-        <param name="min_y" value="$(var min_y)" />
-        <param name="max_y" value="$(var max_y)" />
-        <param name="min_z" value="$(var min_z)" />
-        <param name="max_z" value="$(var max_z)" />
-        <param name="negative" value="$(var negative)" />
+        <param from="$(var config_file)"/> 
         </composable_node>
     </load_composable_node>  
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/preprocessor.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/preprocessor.launch.xml
@@ -9,7 +9,6 @@
     <arg name="output_points_raw" default="/points_raw/cropbox/filtered" description=""/>
     <arg name="tf_output_frame" default="base_link" description=""/>
     <arg name="separate_concatenate_node_and_time_sync_node" default="true" description=""/>
-    <arg name="use_multiple_inputs" default="false" description="Set true if using multiple input topics." />
     <arg name="min_x" default="-3.0" description="Crop Box Limit Min in X"/>
     <arg name="max_x" default="3.0" description="Crop Box Limit Max in X"/>
     <arg name="min_y" default="-2.0" description="Crop Box Limit Min in Y"/>


### PR DESCRIPTION

## Description

- The goal is to add the cropbox filter limits as input parameters.

## How was this PR tested?

- After the test, the launch file in .xml behaved as expected.
- The cropbox size changes with the input arguments.

![Screenshot from 2024-11-08 10-03-31](https://github.com/user-attachments/assets/3b6a1593-eb2a-4f3d-b280-78a5bc1b1547)


## ROS Parameter Changes

### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `min_x`   | `double` | `-3.0`         | Crop Box Limit Min in X |
| Added | `max_x`   | `double` | `3.0`         | Crop Box Limit Max in X |
| Added | `min_y`   | `double` | `-2.0`         | Crop Box Limit Min in Y |
| Added | `max_y`   | `double` | `3.0`         | Crop Box Limit Max in Y |
| Added | `min_z`   | `double` | `0.0`         | Crop Box Limit Min in Z |
| Added | `max_z`   | `double` | `2.5`         | Crop Box Limit Max in Z |
| Added | `negative`   | `bool` | `true`         | Crop zone: false->remove outside | true->remove inside |

## Effects on system behavior

None.


